### PR TITLE
fix: discards record fully transparent color

### DIFF
--- a/app/src/main/java/com/xposed/miuiime/MainHook.kt
+++ b/app/src/main/java/com/xposed/miuiime/MainHook.kt
@@ -124,6 +124,8 @@ class MainHook : IXposedHookLoadPackage {
             findMethod("com.android.internal.policy.PhoneWindow") {
                 name == "setNavigationBarColor" && parameterTypes.sameAs(Int::class.java)
             }.hookAfter { param ->
+                if (param.args[0] == 0) return@hookAfter
+
                 navBarColor = param.args[0] as Int
                 customizeBottomViewColor(clazz)
             }


### PR DESCRIPTION
舍弃记录完全透明的导航栏背景颜色, 可用于解决进入 Gboard 设置后, 底部颜色异常的问题(#24)