### PR TITLE
Fix IME support hook after service recreation

### DIFF
--- a/app/src/main/java/com/xposed/miuiime/MainHook.kt
+++ b/app/src/main/java/com/xposed/miuiime/MainHook.kt
@@ -34,6 +34,7 @@ class MainHook : IXposedHookLoadPackage {
         "com.miui.catcherpatch",
         "com.xiaomi.type",
     )
+    private val hookedImeSupportClasses = mutableSetOf<Class<*>>()
     private var navBarColor: Int? = null
 
     override fun handleLoadPackage(lpparam: XC_LoadPackage.LoadPackageParam) {
@@ -59,7 +60,7 @@ class MainHook : IXposedHookLoadPackage {
                     ?: loadClassOrNull("android.inputmethodservice.InputMethodServiceStubImpl")
 
             sInputMethodServiceInjector?.also {
-                hookSIsImeSupport(it)
+                hookImeSupport(it)
                 hookIsXiaoAiEnable(it)
                 setPhraseBgColor(it)
             } ?: Log.e("Failed:Class not found: InputMethodServiceInjector")
@@ -78,8 +79,11 @@ class MainHook : IXposedHookLoadPackage {
             val dexPath = param.args[1] as String
             // 系统原始逻辑，若已加载dex则直接返回，避免重复hook
             if (loader !is BaseDexClassLoader) throw NoSuchMethodException("addDexPath method not found.")
-            runCatching {
+            val loadedBottomManager = runCatching {
                 Class.forName("com.miui.inputmethod.InputMethodBottomManager", true, loader)
+            }.getOrNull()
+            if (loadedBottomManager != null) {
+                if (isNonCustomize) hookImeSupport(loadedBottomManager)
                 param.result = null
                 return@hookBefore
             }
@@ -94,7 +98,7 @@ class MainHook : IXposedHookLoadPackage {
                 loader
             )?.also {
                 if (isNonCustomize) {
-                    hookSIsImeSupport(it)
+                    hookImeSupport(it)
                     hookIsXiaoAiEnable(it)
                 }
 
@@ -121,6 +125,27 @@ class MainHook : IXposedHookLoadPackage {
             Log.i("Success:Hook field sIsImeSupport")
         }.onFailure {
             Log.i("Failed:Hook field sIsImeSupport")
+            Log.i(it)
+        }
+    }
+
+    /**
+     * 恢复可能被输入法服务 onDestroy 重置的缓存字段，并 hook 判定方法防止再次失效。
+     */
+    private fun hookImeSupport(clazz: Class<*>) {
+        hookSIsImeSupport(clazz)
+        if (hookedImeSupportClasses.contains(clazz)) return
+
+        kotlin.runCatching {
+            val methods = clazz.declaredMethods.filter {
+                it.name == "isImeSupport" && it.returnType == Boolean::class.javaPrimitiveType
+            }
+            if (methods.isEmpty()) throw NoSuchMethodException("${clazz.name}.isImeSupport")
+            methods.forEach { it.hookReturnConstant(true) }
+            hookedImeSupportClasses.add(clazz)
+            Log.i("Success:Hook method isImeSupport")
+        }.onFailure {
+            Log.i("Failed:Hook method isImeSupport")
             Log.i(it)
         }
     }

--- a/app/src/main/res/values/array.xml
+++ b/app/src/main/res/values/array.xml
@@ -8,5 +8,6 @@
         <item>com.sohu.inputmethod.sogou.xiaomi</item>
         <item>com.baidu.input_mi</item>
         <item>com.google.android.inputmethod.latin</item>
+        <item>com.xiaomi.type</item>
     </string-array>
 </resources>


### PR DESCRIPTION
## Summary
- Restore the IME support cache whenever the bottom manager class is reused.
- Hook boolean isImeSupport methods to keep the support result enabled after service recreation.
- Add com.xiaomi.type to the recommended LSPosed scope.

## Root cause
InputMethodBottomManager.onDestroy resets sIsImeSupport to -1. When the dex and class were already loaded, the existing early-return path skipped reapplying the IME support state, so the hook appeared to drop after input method service recreation in the same process.

## Validation
- Release build completed successfully with R8 and vital lint.
- On the test device, switching Gboard to Sogou and back to Gboard kept the same Gboard PID and the IME support hook remained active.